### PR TITLE
Resetting end-of-module dates per official calendar

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -101,17 +101,11 @@ export const createPairingsForQuery = (chosenAvails, inning, pairerId) => {
 
 export const getDaysRemaining = () => {
   const endDates = [
-    new Date('Thu June 6 2019'),
-    new Date('Thu August 1 2019'),
-    new Date('Thu September 19 2019'),
-    new Date('Thu November 7 2019'),
-    new Date('Thu January 16 2020'),
-    new Date('Thu March 5 2020'),
-    new Date('Thu April 23 2020'),
-    new Date('Thu June 11 2020'),
-    new Date('Thu August 6 2020'),
-    new Date('Thu September 24 2020'),
-    new Date('Thu November 12 2020')
+    new Date('Thu November 12 2020'),
+    new Date('Thu January 21 2021'),
+    new Date('Thu March 11 2021'),
+    new Date('Thu April 29 2021'),
+    new Date('Thu June 17 2021')
   ];
   const today = new Date();
   const nextEndDate = endDates.find(date => {


### PR DESCRIPTION
Resets the end-of-module dates that are hard-coded into the front-end per the dates in the 2020 academic calendar doc [here](https://drive.google.com/file/d/1BG0X9yHbpVbxOQX9qZ9SXs7vC2mph_bI/view). The latest date is now **Thu June 17 2021**.

### Issues Resolved
Does not fix #91 but gives us a few more months to come up with a solution.