### PR TITLE
Sync readme & GraphQL docs with backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Paired 2.0 was built by a team of students in Turing's Back-End Engineering prog
 
 The Rock & Pebble feature adds the ability for Paired users to offer to be peer mentors, search for and request peer mentors, and manage their mentors/mentees. Building on the previous 2.0 work, it sends descriptive email notifications throughout the process.  By adding this feature we hope to support the grassroots tradition at Turing of upper-module students ("rocks") being partnered with lower-module students ("pebbles") to support their journey. 
 
-The Rock & Pebble feature was developed over the course of 2020 by a group of 1909 back-end and front-end graduates, some from the original dev team and some new contributors.
+The Rock & Pebble feature was developed over the course of 2020 by a group of 1909 back-end and front-end graduates, some from the original dev team and some new contributors. The development took place on forks of the BE and FE repos, which are now archived but can be found [here](https://github.com/PairedStaging/paired-be) and [here](https://github.com/PairedStaging/paired-fe) respectively for future reference.
 
 ## Agile Development
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Paired 2.0
+# Paired Front-End
 
 ## Table of Contents
 
@@ -6,9 +6,10 @@
 - [Local Deployment](#local-deployment)
 - [Dev Team](#dev-team)
 - [Description](#description)
+- [Rock & Pebble Feature](#rock--pebble-feature)
 - [Agile Development](#agile-development)
 - [Technologies & Architectures](#technologies--architecture)
-- [React & Redux Tutorial](#react-and-redux-tutorial)
+- [React & Redux Tutorial](#react--redux-tutorial)
 - [Testing & Performance](#testing--performance)
 - [PostgreSQL Schema](#postgresql-schema)
 - [GraphQL Endpoints](#graphql-endpoints)
@@ -16,7 +17,7 @@
 
 ## Deployed App
 
-Vist the deployed Paired 2.0 app at [https://www.paired.tech/](https://www.paired.tech/).
+Vist the deployed Paired app at [https://www.paired.tech/](https://www.paired.tech/).
 
 ## Local Deployment
 
@@ -29,6 +30,14 @@ Paired 2.0's dev team is:
  - Daniel Frampton ([GitHub](https://github.com/DanielEFrampton), [LinkedIn](https://www.linkedin.com/in/danielframpton/))
  - Matt Simon ([GitHub](https://github.com/msimon42), [LinkedIn](https://www.linkedin.com/in/matt-simon-83aa5380/))
  - Rebecca Robran ([GitHub](https://github.com/rer7891), [LinkedIn](https://www.linkedin.com/in/rebecca-robran/))
+
+Rock & Pebble feature's dev team:
+ - Rebecca Robran, BE/FE ([@rer7891](https://github.com/rer7891), [LinkedIn](https://www.linkedin.com/in/rebecca-robran/))
+ - Rachel Lew, BE ([@rlew421](https://github.com/rlew421), [LinkedIn](https://www.linkedin.com/in/rlew/))
+ - Matt Simon, BE ([@msimon42](https://github.com/msimon42), [LinkedIn](https://www.linkedin.com/in/matt-simon-83aa5380/))
+ - Linda Le, BE ([@linda-le1](https://github.com/linda-le1), [LinkedIn](https://www.linkedin.com/in/linda-lewang/))
+ - Daniel Frampton, BE/FE ([@DanielEFrampton](https://github.com/DanielEFrampton), [LinkedIn](https://www.linkedin.com/in/danielframpton/))
+ - Caleb Haizlett, FE ([@CHaiz15](https://github.com/CHaiz15), [LinkedIn](https://www.linkedin.com/in/caleb-haizlett/))
 
 The original Paired dev team is:
 - Front End Team
@@ -45,6 +54,12 @@ This repo contains the Paired 2.0 Front-end, a React/Redux app. It derives data 
 Together, these micro-services facilitate paired programming and peer mentoring between [Turing](http://turing.io) students throughout their seven-month immersive program. Students later in the program can create available booking slots, and students earlier in the program can browse those and book paired sessions.
 
 Paired 2.0 was built by a team of students in Turing's Back-End Engineering program. It adds SMS and email notifications of bookings and a user statistics dashboard to the [original Paired app](http://paired.tech) ([front-end repo](https://github.com/hillstew/paired-fe), [back-end repo](https://github.com/dForDeveloper/paired-api)) which was built by Front-end students in April of 2019. They graciously allowed contributions to the app and were helpful throughout this process. You can view the original project's Readme file [here]('original_README.md').
+
+## Rock & Pebble Feature
+
+The Rock & Pebble feature adds the ability for Paired users to offer to be peer mentors, search for and request peer mentors, and manage their mentors/mentees. Building on the previous 2.0 work, it sends descriptive email notifications throughout the process.  By adding this feature we hope to support the grassroots tradition at Turing of upper-module students ("rocks") being partnered with lower-module students ("pebbles") to support their journey. 
+
+The Rock & Pebble feature was developed over the course of 2020 by a group of 1909 back-end and front-end graduates, some from the original dev team and some new contributors.
 
 ## Agile Development
 
@@ -132,6 +147,17 @@ To make live queries to the GraphQL endpoint and see live schema information, se
   - [deletePairings](graphql_endpoints.md#delete-pairings)
 - Filter Queries
   - [getPairing](graphql_endpoints.md#get-pairing)
+- Rock & Pebble Queries & Mutations
+  - Queries
+    - [getUserRockAndPebbles](graphql_endpoints.md#get-user-rocks-and-pebbles)
+  - Mutations
+    - [rockOptInOut](graphql_endpoints.md#rock-opt-in-out)
+    - [createRockPebbleRelationship](graphql_endpoints.md#create-rock-pebble-relationship)
+    - [activateRockPebbleRelationship](graphql_endpoints.md#activate-rock-pebble-relationship)
+    - [declineRockPebbleRelationship](graphql_endpoints.md#decline-rock-pebble-relationship)
+    - [discontinueRockPebbleRelationship](graphql_endpoints.md#discontinue-rock-pebble-relationship)
+  - Filter Queries
+    - [findAvailableRocks](graphql_endpoints.md#find-available-rocks)
 
 ## Resource Credits
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Paired 2.0 was built by a team of students in Turing's Back-End Engineering prog
 
 The Rock & Pebble feature adds the ability for Paired users to offer to be peer mentors, search for and request peer mentors, and manage their mentors/mentees. Building on the previous 2.0 work, it sends descriptive email notifications throughout the process.  By adding this feature we hope to support the grassroots tradition at Turing of upper-module students ("rocks") being partnered with lower-module students ("pebbles") to support their journey. 
 
-The Rock & Pebble feature was developed over the course of 2020 by a group of 1909 back-end and front-end graduates, some from the original dev team and some new contributors. The development took place on forks of the BE and FE repos, which are now archived but can be found [here](https://github.com/PairedStaging/paired-be) and [here](https://github.com/PairedStaging/paired-fe) respectively for future reference.
+The Rock & Pebble feature was developed over the course of 2020 by a group of 1909 back-end and front-end graduates, some from the Paired 2.0 dev team and some new contributors. The development took place on forks of the BE and FE repos, which are now archived but can be found [here](https://github.com/PairedStaging/paired-be) and [here](https://github.com/PairedStaging/paired-fe) respectively for future reference.
 
 ## Agile Development
 

--- a/graphql_endpoints.md
+++ b/graphql_endpoints.md
@@ -285,7 +285,7 @@ Our GraphQL endpoints fall into three categories: queries, mutations, and filter
 }
   ```
 
-6. [**getPairing (id: ID)**](#get-pairing)  *Finds a specific pairing by pairing id*
+6. [**getPairing(id: ID)**](#get-pairing)  *Finds a specific pairing by pairing id*
   * Example Query
   ```
   { getPairing(id: "1") {
@@ -338,7 +338,7 @@ Our GraphQL endpoints fall into three categories: queries, mutations, and filter
   }
   ```
 
-8. [**getUserStats (id: ID)**](#get-user-stats)  *Returns a specific users statistics on pairing hours*
+8. [**getUserStats(id: ID)**](#get-user-stats) *Returns a specific users statistics on pairing hours*
   * Example Query
   ```
   {
@@ -723,6 +723,515 @@ Our GraphQL endpoints fall into three categories: queries, mutations, and filter
           "date": "Wed Apr 03 2020",
           "time": "lunch",
           "id": "4082"
+        }
+      ]
+    }
+  }
+  ```
+### Rock And Pebble Queries and Mutations
+
+#### Queries
+
+1. [**getUserRocksAndPebble(id: ID)**](#get-user-rocks-and-pebbles) *Returns all Rock and Pebble relationships by User*
+  * Example Query
+  ```
+  getUserRockAndPebble(id: 4) {
+      myRocks {
+        name
+        module
+        program
+        id
+        pronouns
+        skills
+        slack
+        image
+      }
+      myPebbles {
+        name
+        module
+        program
+        id
+        pronouns
+        skills
+        slack
+        image
+      }
+      pendingPebbles {
+        name
+        module
+        program
+        id
+        pronouns
+        skills
+        slack
+        image
+      } 
+      pendingRocks {
+        name
+        module
+        program
+        id
+        pronouns
+        skills
+        slack
+        image
+      }  
+    }
+  }
+  ``` 
+  * Example Response
+  ```json
+  {
+  "data": {
+    "getUserRockAndPebble": {
+      "myRocks": [
+        {
+          "name": "Kenny Penny",
+          "module": "5",
+          "program": "BE",
+          "id": "4",
+          "pronouns": "she/her",
+          "skills": [
+            "Chad Terbocks",
+            "Walter Melon",
+            "Bob Ng"
+          ],
+          "slack": "Olive Hoyl",
+          "image": "https://loremflickr.com/300/300"
+        }
+      ],
+      "myPebbles": [
+        {
+          "name": "Frank Furter",
+          "module": "2",
+          "program": "BE",
+          "id": "3",
+          "pronouns": "She/her",
+          "skills": [
+            "Ferris Wheeler",
+            "Hilda Climb",
+            "Woody Forrest",
+            "Seymour Legg"
+          ],
+          "slack": "Cole Kutz",
+          "image": "https://loremflickr.com/300/300"
+        }
+      ],
+      "pendingPebbles": [],
+      "pendingRocks": []
+    }
+  }
+}
+```
+
+#### Mutations
+
+1. [**rockOptInOut(input: {id: ID!})**](#rock-opt-in-out) *Allows a user to opt in or out of being available as a Rock*
+  * Example Query
+  ```
+  mutation {
+      updateUserOptinStatus(
+        input: {
+          id: "1"
+        })
+        {
+          rockOptIn
+      }
+    }
+  ``` 
+  * Example Response
+  ```json
+  {
+    "data": {
+      "updateUserOptinStatus": {
+        "rockOptIn": false
+      }
+    }
+  }
+  ```
+
+2. [**createRockPebbleRelationship(input: {rockId: ID!, pebbleId: ID!})**](#create-rock-pebble-relationship)  *Creates initial Rock and Pebble Relationship*
+  * Example Query
+  ```
+  mutation {
+    createRockPebbleRelationship(
+      input: {
+        rockId: "1"
+        pebbleId: "4"
+      })
+    {
+      myRocks {
+        name
+        module
+        program
+        id
+        pronouns
+        skills
+        slack
+        image
+      }
+      myPebbles {
+        name
+        module
+        program
+        id
+        pronouns
+        skills
+        slack
+        image
+      }
+      pendingPebbles {
+        name
+        module
+        program
+        id
+        pronouns
+        skills
+        slack
+        image
+      } 
+      pendingRocks {
+        name
+        module
+        program
+        id
+        pronouns
+        skills
+        slack
+        image
+      } 
+    }
+  }
+  ```
+  * Example Response
+  ```json
+  {
+    "data": {
+      "createRockPebbleRelationship": {
+        "myRocks": [],
+        "myPebbles": [
+          {
+            "name": "Becky Simpson",
+            "module": "4",
+            "program": "BE",
+            "id": "11",
+            "pronouns": "",
+            "skills": [
+              "grid",
+              "flexbox",
+              "Graphql "
+            ],
+            "slack": "3srtr4",
+            "image": "https://avatars1.githubusercontent.com/u/52762517?v=4"
+          }
+        ],
+        "pendingPebbles": [],
+        "pendingRocks": [
+          {
+            "name": "Sarah Clarkson",
+            "module": "5",
+            "program": "BE",
+            "id": "14",
+            "pronouns": "",
+            "skills": [
+              "grid",
+              "flexbox",
+              "Graphql "
+            ],
+            "slack": "som342",
+            "image": "https://avatars1.githubusercontent.com/u/52762517?v=4"
+          }
+        ]
+      }
+    }
+  }
+  ```
+
+3. [**activateRockPebbleRelationship(input: {rockId: ID!, pebbleId: ID!})**](#activate-rock-pebble-relationship) *Activates a Rock and Pebble Relationship once a Rock accepts*
+  * Example Query
+  ```
+  mutation {
+      activateRockPebbleRelationship(
+        input: {
+          rockId: "1"
+          pebbleId: "4"
+        })
+      {
+        myRocks {
+          name
+          module
+          program
+          id
+          pronouns
+          skills
+          slack
+          image
+        }
+        myPebbles {
+          name
+          module
+          program
+          id
+          pronouns
+          skills
+          slack
+          image
+        }
+        pendingPebbles {
+          name
+          module
+          program
+          id
+          pronouns
+          skills
+          slack
+          image
+        } 
+        pendingRocks {
+          name
+          module
+          program
+          id
+          pronouns
+          skills
+          slack
+          image
+        } 
+      }
+    }
+  ```
+  * Example Response
+  ```json
+  {
+    "data": {
+      "activateRockPebbleRelationship": {
+        "myRocks": [
+        {
+            "name": "Sarah Clarkson",
+            "module": "5",
+            "program": "BE",
+            "id": "14",
+            "pronouns": "",
+            "skills": [
+              "grid",
+              "flexbox",
+              "Graphql "
+            ],
+            "slack": "som342",
+            "image": "https://avatars1.githubusercontent.com/u/52762517?v=4"
+          }
+        ],
+        "myPebbles": [
+          {
+            "name": "Becky Simpson",
+            "module": "4",
+            "program": "BE",
+            "id": "11",
+            "pronouns": "",
+            "skills": [
+              "grid",
+              "flexbox",
+              "Graphql "
+            ],
+            "slack": "3srtr4",
+            "image": "https://avatars1.githubusercontent.com/u/52762517?v=4"
+          }
+        ],
+        "pendingPebbles": [],
+        "pendingRocks": []
+      }
+    }
+  }
+  ```
+
+4. [**declineRockPebbleRelationship(input: {rockId: ID!, pebbleId: ID!, reason: String!})**](#decline-rock-pebble-relationship) *Destroys a Rock and Pebble Relationship if a Rock declines relationship*
+  * Example Query
+  ```
+  mutation {
+      declineRockPebbleRelationship(
+        input: {
+          rockId: "1"
+          pebbleId: "4"
+          reason: "I no longer wish to be available as a rock."
+        })
+      {
+        myRocks {
+          name
+          module
+          program
+          id
+          pronouns
+          skills
+          slack
+          image
+        }
+        myPebbles {
+          name
+          module
+          program
+          id
+          pronouns
+          skills
+          slack
+          image
+        }
+        pendingPebbles {
+          name
+          module
+          program
+          id
+          pronouns
+          skills
+          slack
+          image
+        } 
+        pendingRocks {
+          name
+          module
+          program
+          id
+          pronouns
+          skills
+          slack
+          image
+        } 
+      }
+    }
+  ```
+  * Example Response
+  ```json
+  {
+    "data": {
+      "declineRockPebbleRelationship": {
+        "myRocks": [],
+        "myPebbles": [
+          {
+            "name": "Becky Simpson",
+            "module": "4",
+            "program": "BE",
+            "id": "11",
+            "pronouns": "",
+            "skills": [
+              "grid",
+              "flexbox",
+              "Graphql "
+            ],
+            "slack": "3srtr4",
+            "image": "https://avatars1.githubusercontent.com/u/52762517?v=4"
+          }
+        ],
+        "pendingPebbles": [],
+        "pendingRocks": []
+      }
+    }
+  }
+  ```
+
+5. [**discontinueRockPebbleRelationship(input: {rockId: ID!, pebbleId: ID!, reason: String!, userRelationship: String!})**](#discontinue-rock-pebble-relationship) *Updates a Rock and Pebble Relationship to inactive*
+  * Example Query
+  ```
+  mutation {
+      discontinueRockPebbleRelationship(
+        input: {
+          rockId: "1"
+          pebbleId: "4"
+          reason:"I'm too busy."
+          userRelationship: "pebble"
+        })
+      {
+        myRocks {
+          name
+          module
+          program
+          id
+          pronouns
+          skills
+          slack
+          image
+        }
+        myPebbles {
+          name
+          module
+          program
+          id
+          pronouns
+          skills
+          slack
+          image
+        }
+        pendingPebbles {
+          name
+          module
+          program
+          id
+          pronouns
+          skills
+          slack
+          image
+        } 
+        pendingRocks {
+          name
+          module
+          program
+          id
+          pronouns
+          skills
+          slack
+          image
+        } 
+      }
+    }
+  ```
+  * Example Response
+  ```json
+  {
+    "data": {
+      "discontinueRockPebbleRelationship": {
+        "myRocks": [],
+        "myPebbles": [],
+        "pendingPebbles": [],
+        "pendingRocks": []
+      }
+    }
+  }
+  ```
+
+#### Filter Queries
+
+1. [**findAvailableRocks(filter: {program: String, module: Int})**](#find-available-rocks) *Searches for Rocks that are opted in to the program by program and module*
+  * Example Query
+  ```
+  {
+      findAvailableRocks(filter: { program: "BE", module: 5}) {
+        name
+        module
+        program
+        id
+        pronouns
+        skills
+        slack
+        image
+      }
+    }
+  ```
+  * Example Response
+  ```json
+  {
+    "data": {
+      "findAvailableRocks": [
+        {
+          "name": "Kenny Penny",
+          "module": "5",
+          "program": "BE",
+          "id": "4",
+          "pronouns": "she/her",
+          "skills": [
+            "Chad Terbocks",
+            "Walter Melon",
+            "Bob Ng"
+          ],
+          "slack": "Olive Hoyl",
+          "image": "https://loremflickr.com/300/300"
         }
       ]
     }


### PR DESCRIPTION
### Issues Resolved
Just something I noticed :)

### Problem Addressed
We updated the readme and GraphQL documentation on the back-end repo when we merged the Rock & Pebble feature, but forgot to update the docs on the front-end repo as well.

### Solution Implemented
Did a file comparison and copied content relevant to the front-end from the back-end readme, and copied the GraphQL docs over entirely.

### GIF me
![badly assembling ikea furniture](https://media.giphy.com/media/ZvkHeRqClNgUE/giphy-downsized-large.gif)
