### PR TITLE
Update mod end dates through June 2023

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -101,11 +101,20 @@ export const createPairingsForQuery = (chosenAvails, inning, pairerId) => {
 
 export const getDaysRemaining = () => {
   const endDates = [
-    new Date('Thu November 12 2020'),
-    new Date('Thu January 21 2021'),
-    new Date('Thu March 11 2021'),
-    new Date('Thu April 29 2021'),
-    new Date('Thu June 17 2021')
+    new Date('Thu August 12 2021'),
+    new Date('Thu September 30 2021'),
+    new Date('Thu November 18 2021'),
+    new Date('Thu January 20 2022'),
+    new Date('Thu March 10 2022'),
+    new Date('Thu April 28 2022'),
+    new Date('Thu June 16 2022'),
+    new Date('Thu August 11 2022'),
+    new Date('Thu September 29 2022'),
+    new Date('Thu November 17 2022'),
+    new Date('Thu January 19 2023'),
+    new Date('Thu March 9 2023'),
+    new Date('Thu April 27 2023'),
+    new Date('Thu June 15 2023')
   ];
   const today = new Date();
   const nextEndDate = endDates.find(date => {


### PR DESCRIPTION
### Issues Resolved
Deal again with the symptoms but not the cause of #91

### Problem Addressed

We ran out of module end dates again 🤦 

### Solution Implemented

Added end dates through June 2023 according to the calendars available on Turing's website [here](https://frontend.turing.edu/today/calendars/2021Calendar.pdf) and [here](https://frontend.turing.edu/today/calendars/2022Calendar.pdf)

### Other Notes

Maintaining public projects is hard! Consider contributing to Paired today! :D
